### PR TITLE
added two new static method

### DIFF
--- a/connectors/base.py
+++ b/connectors/base.py
@@ -142,3 +142,21 @@ class BasicConnector(ABC):
     @staticmethod
     def get_service_from_name(name):
         raise NotImplementedError
+
+    @staticmethod
+    def get_service_from_name(name):
+        """
+        Returns the service object based on the service name
+        :param name: The name of the service
+        :return: The service object
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_node_from_ip(ip_address):
+        """
+        Returns the node object based on the IP address
+        :param ip_address: The IP address of the node
+        :return: The node object
+        """
+        raise NotImplementedError


### PR DESCRIPTION
user can use these two static method 

The get_service_from_name method can be used to retrieve a specific service object from a container orchestration system by name. This can be helpful for managing and scaling services in a fog or edge computing environment, where multiple services may be running on different nodes.

The get_node_from_ip method can be used to retrieve a specific node object from a container orchestration system by IP address. This can be helpful for managing and monitoring nodes in a fog or edge computing environment, where nodes may be spread out geographically and need to be monitored and managed remotely.

Both of these methods provide a convenient and standardized way to interact with container orchestration systems, which can help streamline the development and management of fog and edge computing applications.